### PR TITLE
Activation token in auth controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 obj
 *.db
 *.db-journal
+*.sln.DotSettings.user

--- a/PictureApp.API.Dtos/NotificationDto.cs
+++ b/PictureApp.API.Dtos/NotificationDto.cs
@@ -1,0 +1,9 @@
+﻿namespace PictureApp.API.Dtos
+{
+    public class NotificationDto
+    {
+        public string Subject { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/PictureApp.API.Dtos/UserForDetailedDto.cs
+++ b/PictureApp.API.Dtos/UserForDetailedDto.cs
@@ -6,5 +6,6 @@ namespace PictureApp.API.Dtos
         public string Username { get; set; }
         public string Email { get; set; }
         public string PhotoUrl { get; set; }
+        public string ActivationToken { get; set; }
     }
 }

--- a/PictureApp.API.Dtos/UserForRegisterActivateDto.cs
+++ b/PictureApp.API.Dtos/UserForRegisterActivateDto.cs
@@ -1,0 +1,7 @@
+﻿namespace PictureApp.API.Dtos
+{
+    public class UserForRegisterActivateDto
+    {
+        public string Token { get; set; }
+    }
+}

--- a/PictureApp.API.Models/User.cs
+++ b/PictureApp.API.Models/User.cs
@@ -12,7 +12,6 @@ namespace PictureApp.API.Models
         public bool IsAccountActivated { get; set; }
         public ICollection<Photo> Photos { get; set; }
         public ICollection<UserFollower> Followers { get; set; }
-        public ICollection<UserFollower> Following { get; set; }        
-        
+        public ICollection<UserFollower> Following { get; set; }
     }
 }

--- a/PictureApp.API.Services/EmailNotificationService.cs
+++ b/PictureApp.API.Services/EmailNotificationService.cs
@@ -1,53 +1,44 @@
 ﻿using System;
-using System.Linq;
 using System.Net.Mail;
-using System.Text;
 using System.Threading.Tasks;
-using MoreLinq.Extensions;
-using PictureApp.API.Services.NotificationTemplateData;
-using PictureApp.API.Data.Repositories;
-using PictureApp.API.Extensions.Exceptions;
-using PictureApp.API.Models;
 using PictureApp.API.Providers;
+using PictureApp.Notifications;
 
 namespace PictureApp.API.Services
 {
     public class EmailNotificationService : INotificationService
     {
-        private readonly IRepository<NotificationTemplate> _repository;
         private readonly IEmailClientProvider _emailClientProvider;
+        private readonly INotificationTemplateService _notificationTemplateService;
 
-        public EmailNotificationService(IRepository<NotificationTemplate> repository,
-            IEmailClientProvider emailClientProvider)
+        public EmailNotificationService(IEmailClientProvider emailClientProvider, INotificationTemplateService notificationTemplateService)
         {
-            _repository = repository ?? throw new ArgumentNullException(nameof(repository));
             _emailClientProvider = emailClientProvider ?? throw new ArgumentNullException(nameof(emailClientProvider));
+            _notificationTemplateService = notificationTemplateService ?? throw new ArgumentNullException(nameof(notificationTemplateService));
         }
 
         public async Task SendAsync(string recipient, INotificationTemplateData templateData)
         {
-            // Attempt to get the template identified by an abbreviation
-            var notificationTemplate = _repository.Find(x => x.Abbreviation == templateData.TemplateAbbreviation)
-                .FirstOrDefault();
-            if (notificationTemplate == null)
+            if (templateData == null)
             {
-                throw new EntityNotFoundException(
-                    $"Can not find notification template with following abbreviation: {templateData.TemplateAbbreviation}");
+                throw new ArgumentNullException(nameof(templateData));
             }
-           
-            // Prepare the email body
-            var body = GetEmailBody(notificationTemplate.Body, templateData);
+
+            MailAddress recipientMailAddress;
+
+            try
+            {
+                recipientMailAddress = new MailAddress(recipient);
+            }
+            catch (FormatException e)
+            {
+                throw new ArgumentException($"Incorrect format for passed recipient email: `{recipient}`.", e);
+            }
+
+            var notification = await _notificationTemplateService.CreateNotification(templateData);
 
             // Send the email via gateway client
-            await _emailClientProvider.SendAsync(new MailAddress(recipient), notificationTemplate.Subject, body);
-        }
-
-        private string GetEmailBody(string template, INotificationTemplateData templateData)
-        {
-            var body = new StringBuilder(template);
-
-            templateData.GetKeys().ForEach(key => body.Replace(key, templateData.GetValue(key)));
-            return body.ToString();
+            await _emailClientProvider.SendAsync(recipientMailAddress, notification.Subject, notification.Body);
         }
     }
 }

--- a/PictureApp.API.Services/INotificationService.cs
+++ b/PictureApp.API.Services/INotificationService.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using PictureApp.API.Services.NotificationTemplateData;
+using PictureApp.Notifications;
 
 namespace PictureApp.API.Services
 {

--- a/PictureApp.API.Services/INotificationTemplateService.cs
+++ b/PictureApp.API.Services/INotificationTemplateService.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using PictureApp.API.Dtos;
+using PictureApp.Notifications;
+
+namespace PictureApp.API.Services
+{
+    public interface INotificationTemplateService
+    {
+        Task<NotificationDto> CreateNotification(INotificationTemplateData templateData);
+    }
+}

--- a/PictureApp.API.Services/IUserService.cs
+++ b/PictureApp.API.Services/IUserService.cs
@@ -7,8 +7,7 @@ namespace PictureApp.API.Services
     public interface IUserService
     {
         UserForDetailedDto GetUser(int userId);
-        Task<IEnumerable<UsersListWithFollowersForExploreDto>> GetAllWithFollowers(int userId);
-
         UserForDetailedDto GetUser(string email);
+        Task<IEnumerable<UsersListWithFollowersForExploreDto>> GetAllWithFollowers(int userId);
     }
 }

--- a/PictureApp.API.Services/IUserService.cs
+++ b/PictureApp.API.Services/IUserService.cs
@@ -5,5 +5,7 @@ namespace PictureApp.API.Services
     public interface IUserService
     {
         UserForDetailedDto GetUser(int userId);
+
+        UserForDetailedDto GetUser(string email);
     }
 }

--- a/PictureApp.API.Services/NotificationTemplateService.cs
+++ b/PictureApp.API.Services/NotificationTemplateService.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using MoreLinq.Extensions;
+using PictureApp.API.Data.Repositories;
+using PictureApp.API.Dtos;
+using PictureApp.API.Models;
+using PictureApp.Notifications;
+
+namespace PictureApp.API.Services
+{
+    public class NotificationTemplateService : INotificationTemplateService
+    {
+        private readonly IRepository<NotificationTemplate> _repository;
+
+        public NotificationTemplateService(IRepository<NotificationTemplate> repository)
+        {
+            _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        }
+
+        public async Task<NotificationDto> CreateNotification(INotificationTemplateData templateData)
+        {
+            if (templateData == null)
+            {
+                throw new ArgumentNullException(nameof(templateData));
+            }
+
+            var notificationTemplate = await 
+                _repository.SingleOrDefaultAsync(x => x.Abbreviation == templateData.TemplateAbbreviation);
+
+            if (notificationTemplate == null)
+            {
+                throw new ArgumentException(
+                    $"The notification template with abbreviation: {templateData.TemplateAbbreviation} does not exist in data store.");
+            }
+
+            return new NotificationDto
+                {Body = GetBody(notificationTemplate.Body, templateData), Subject = notificationTemplate.Subject};
+        }
+
+        private string GetBody(string template, INotificationTemplateData templateData)
+        {
+            var body = new StringBuilder(template);
+
+            templateData.GetKeys().ForEach(key => body = body.Replace(key, templateData.GetValue(key)));
+            return body.ToString();
+        }
+    }
+}

--- a/PictureApp.API.Services/PictureApp.API.Services.csproj
+++ b/PictureApp.API.Services/PictureApp.API.Services.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\PictureApp.API.Extensions\PictureApp.API.Extensions.csproj" />
     <ProjectReference Include="..\PictureApp.API.Models\PictureApp.API.Models.csproj" />
     <ProjectReference Include="..\PictureApp.API.Providers\PictureApp.API.Providers.csproj" />
+    <ProjectReference Include="..\PictureApp.Notifications\PictureApp.Notifications.csproj" />
   </ItemGroup>
 
 </Project>

--- a/PictureApp.API.Services/UserService.cs
+++ b/PictureApp.API.Services/UserService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using AutoMapper;
 using PictureApp.API.Data.Repositories;
 using PictureApp.API.Dtos;
@@ -25,8 +24,22 @@ namespace PictureApp.API.Services
             var user = _repository.Find(u => u.Id == userId).FirstOrDefault();
 
             if (user == null)
+            {
                 throw new EntityNotFoundException($"user by id {userId} not found");
-                
+            }
+
+            return _mapper.Map<UserForDetailedDto>(user);
+        }
+
+        public UserForDetailedDto GetUser(string email)
+        {
+            var user = _repository.Find(u => u.Email == email.ToLower()).FirstOrDefault();
+
+            if (user == null)
+            {
+                throw new EntityNotFoundException($"User identifies by email {email} does not exist in data store");
+            }
+
             return _mapper.Map<UserForDetailedDto>(user);
         }
     }

--- a/PictureApp.API.Tests/Messaging/UserRegisteredNotificationHandlerTests.cs
+++ b/PictureApp.API.Tests/Messaging/UserRegisteredNotificationHandlerTests.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NUnit.Framework;
+
+namespace PictureApp.API.Tests.Messaging
+{
+    [TestFixture]
+    public class UserRegisteredNotificationHandlerTests
+    {
+
+    }
+}

--- a/PictureApp.API.Tests/PictureApp.API.Tests.csproj
+++ b/PictureApp.API.Tests/PictureApp.API.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\PictureApp.API.Extensions\PictureApp.API.Extensions.csproj" />
     <ProjectReference Include="..\PictureApp.API.Providers\PictureApp.API.Providers.csproj" />
     <ProjectReference Include="..\PictureApp.API.Services\PictureApp.API.Services.csproj" />
+    <ProjectReference Include="..\PictureApp.Notifications\PictureApp.Notifications.csproj" />
   </ItemGroup>
 
   <!--

--- a/PictureApp.API.Tests/Services/EmailNotificationServiceTests.cs
+++ b/PictureApp.API.Tests/Services/EmailNotificationServiceTests.cs
@@ -1,17 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Net.Mail;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
-using PictureApp.API.Data.Repositories;
-using PictureApp.API.Extensions.Exceptions;
-using PictureApp.API.Models;
+using PictureApp.API.Dtos;
 using PictureApp.API.Providers;
 using PictureApp.API.Services;
-using PictureApp.API.Services.NotificationTemplateData;
+using PictureApp.Notifications;
 
 namespace PictureApp.API.Tests.Services
 {
@@ -22,7 +18,7 @@ namespace PictureApp.API.Tests.Services
         public void Ctor_WhenCalledWithNullFirstDependency_ArgumentNullExceptionExpected()
         {
             // ARRANGE
-            Action action = () => new EmailNotificationService(null, Substitute.For<IEmailClientProvider>());
+            Action action = () => new EmailNotificationService(null, Substitute.For<INotificationTemplateService>());
 
             // ACT & ASSERT
             action.Should().Throw<ArgumentNullException>();
@@ -32,7 +28,7 @@ namespace PictureApp.API.Tests.Services
         public void Ctor_WhenCalledWithNullSecondDependency_ArgumentNullExceptionExpected()
         {
             // ARRANGE
-            Action action = () => new EmailNotificationService(Substitute.For<IRepository<NotificationTemplate>>(), null);
+            Action action = () => new EmailNotificationService(Substitute.For<IEmailClientProvider>(), null);
 
             // ACT & ASSERT
             action.Should().Throw<ArgumentNullException>();
@@ -42,84 +38,66 @@ namespace PictureApp.API.Tests.Services
         public void Ctor_WhenCalledWithAllNotNullDependencies_ExceptionDoesNotThrow()
         {
             // ARRANGE
-            Action action = () => new EmailNotificationService(Substitute.For<IRepository<NotificationTemplate>>(),
-                Substitute.For<IEmailClientProvider>());
+            Action action = () => new EmailNotificationService(Substitute.For<IEmailClientProvider>(),
+                Substitute.For<INotificationTemplateService>());
 
             // ACT & ASSERT
             action.Should().NotThrow();
         }
 
         [Test]
-        public void SendAsync_WhenCalledWithUnknownNotificationTemplate_EntityNotFoundExceptionExpected()
+        public void SendAsync_WhenCalledWithNullNotificationTemplateData_ArgumentNullExceptionExpected()
         {
             // ARRANGE
-            var repository = Substitute.For<IRepository<NotificationTemplate>>();
-            repository.Find(Arg.Any<Expression<Func<NotificationTemplate, bool>>>()).Returns(new List<NotificationTemplate>());
-            var service = new EmailNotificationService(repository,
-                Substitute.For<IEmailClientProvider>());
-            Func<Task> action = async () => await service.SendAsync("user@post.com", new SampleNotificationTemplateData());
+            var service = new EmailNotificationService(Substitute.For<IEmailClientProvider>(), Substitute.For<INotificationTemplateService>());
+
+            Func<Task> action = async () => await service.SendAsync("user@post.com", null);
 
             // ACT & ASSERT
-            action.Should().Throw<EntityNotFoundException>().WithMessage("Can not find notification template with following abbreviation: ABR");
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void SendAsync_WhenCalledWithIncorrectRecipientEmail_ArgumentExceptionExpected()
+        {
+            // ARRANGE
+            var service = new EmailNotificationService(Substitute.For<IEmailClientProvider>(), Substitute.For<INotificationTemplateService>());
+            var recipientEmail = "incorrect recipient email";
+            Func<Task> action = async () => await service.SendAsync(recipientEmail, Substitute.For<INotificationTemplateData>());
+
+            // ACT & ASSERT
+            action.Should().Throw<ArgumentException>()
+                .WithMessage($"Incorrect format for passed recipient email: `{recipientEmail}`.");
         }
 
         [Test]
         public async Task SendAsync_WhenCalled_AttemptToSendAnEmailExpected()
         {
             // ARRANGE
-            var notificationTemplate = new NotificationTemplate
-                {Abbreviation = "ABR", Body = "The body content: {content}", Subject = "The subject"};
-            var repository = Substitute.For<IRepository<NotificationTemplate>>();
-            repository.Find(Arg.Any<Expression<Func<NotificationTemplate, bool>>>()).Returns(
-                new List<NotificationTemplate>
-                {
-                    notificationTemplate
-                });
+            var notification = new NotificationDto { Subject = "The subject", Body = "The body" };
+            var notificationTemplateService = Substitute.For<INotificationTemplateService>();
+            notificationTemplateService.CreateNotification(Arg.Any<INotificationTemplateData>()).Returns(notification);            
             MailAddress actualEmailRecipient = null;
             var actualEmailSubject = string.Empty;
             var actualEmailBody = string.Empty;
             var emailClientProvider = Substitute.For<IEmailClientProvider>();
-            emailClientProvider.When(x => x.SendAsync(Arg.Any<MailAddress>(), Arg.Any<string>(), Arg.Any<string>())).Do(x =>
-            {
-                actualEmailRecipient = x.ArgAt<MailAddress>(0);
-                actualEmailSubject = x.ArgAt<string>(1);
-                actualEmailBody = x.ArgAt<string>(2);
-            });
-            var service = new EmailNotificationService(repository,
-                emailClientProvider);
+            emailClientProvider.When(x => x.SendAsync(Arg.Any<MailAddress>(), Arg.Any<string>(), Arg.Any<string>())).Do(
+                x =>
+                {
+                    actualEmailRecipient = x.ArgAt<MailAddress>(0);
+                    actualEmailSubject = x.ArgAt<string>(1);
+                    actualEmailBody = x.ArgAt<string>(2);
+                });
+            var service = new EmailNotificationService(emailClientProvider, notificationTemplateService);
 
             // ACT
-            await service.SendAsync("user@post.com", new SampleNotificationTemplateData());
+            var recipientEmail = "user@post.com";
+            await service.SendAsync(recipientEmail, Substitute.For<INotificationTemplateData>());
 
             // ASSERT
-            actualEmailRecipient.Should().BeEquivalentTo(new MailAddress("user@post.com"));
-            actualEmailSubject.Should().BeEquivalentTo(notificationTemplate.Subject);
-            actualEmailBody.Should()
-                .BeEquivalentTo(notificationTemplate.Body.Replace("\\{content\\}",
-                    "The body content: Lorem ipsum dolor sit amet")
-                );
-        }
-
-        private class SampleNotificationTemplateData : INotificationTemplateData
-        {
-            public string TemplateAbbreviation => "ABR";
-            private readonly IDictionary<string, string> _dictionary = new Dictionary<string, string>();
-
-            public SampleNotificationTemplateData()
-            {
-                _dictionary.Add("\\{content\\}",
-                    "Lorem ipsum dolor sit amet");
-            }
-
-            public IEnumerable<string> GetKeys()
-            {
-                return _dictionary.Keys;
-            }
-
-            public string GetValue(string key)
-            {
-                return _dictionary[key];
-            }
+            actualEmailRecipient.Should().BeEquivalentTo(new MailAddress(recipientEmail));
+            actualEmailSubject.Should().BeEquivalentTo(notification.Subject);
+            actualEmailBody.Should().BeEquivalentTo(notification.Body);
         }
     }
 }

--- a/PictureApp.API.Tests/Services/NotificationTemplateServiceTests.cs
+++ b/PictureApp.API.Tests/Services/NotificationTemplateServiceTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using PictureApp.API.Data.Repositories;
+using PictureApp.API.Dtos;
+using PictureApp.API.Models;
+using PictureApp.API.Services;
+using PictureApp.Notifications;
+
+namespace PictureApp.API.Tests.Services
+{
+    [TestFixture]
+    public class NotificationTemplateServiceTests
+    {
+        [Test]
+        public void Ctor_WhenCalledWithNullDependency_ArgumentNullExceptionExpected()
+        {
+            // ARRANGE
+            Action action = () => new NotificationTemplateService(null);
+
+            // ACT & ASSERT
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void Ctor_WhenCalledWithNotNullDependency_ExceptionDoesNotThrow()
+        {
+            // ARRANGE
+            Action action = () => new NotificationTemplateService(Substitute.For<IRepository<NotificationTemplate>>());
+
+            // ACT & ASSERT
+            action.Should().NotThrow();
+        }
+
+        [Test]
+        public void CreateNotification_WhenCalledWithNull_ArgumentNullExceptionExpected()
+        {
+            // ARRANGE
+            var repository = Substitute.For<IRepository<NotificationTemplate>>();
+            repository.SingleOrDefaultAsync(Arg.Any<Expression<Func<NotificationTemplate, bool>>>())
+                .Returns(new NotificationTemplate());
+            var service = new NotificationTemplateService(repository);
+            Func<Task> action = async () => await service.CreateNotification(null);
+
+            // ACT & ASSERT
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public void CreateNotification_WhenCalledWithTemplateDataNotRelatedToAnyNotificationTemplate_ArgumentExceptionExpected()
+        {
+            // ARRANGE
+            var templateData = Substitute.For<INotificationTemplateData>();
+            templateData.TemplateAbbreviation.Returns("ABC");
+            var repository = Substitute.For<IRepository<NotificationTemplate>>();
+            repository.SingleOrDefaultAsync(Arg.Any<Expression<Func<NotificationTemplate, bool>>>())
+                .Returns((NotificationTemplate) null);
+            var service = new NotificationTemplateService(repository);
+            Func<Task> action = async () => await service.CreateNotification(templateData);
+
+            // ACT & ASSERT
+            action.Should().Throw<ArgumentException>().WithMessage(
+                $"The notification template with abbreviation: {templateData.TemplateAbbreviation} does not exist in data store.");
+        }
+
+        [Test]
+        public async Task CreateNotification_WhenCalled_ProperNotificationExpected()
+        {
+            // ARRANGE
+            var templateData = Substitute.For<INotificationTemplateData>();
+            templateData.GetKeys().Returns(new List<string>{"{body}"});
+            templateData.GetValue("{body}").Returns("The body content");
+            var repository = Substitute.For<IRepository<NotificationTemplate>>();
+            var notificationTemplate = new NotificationTemplate {Abbreviation = "ABC", Body = "{body}", Subject = "The subject"};
+            repository.SingleOrDefaultAsync(Arg.Any<Expression<Func<NotificationTemplate, bool>>>()).Returns(notificationTemplate);
+            var expected = new NotificationDto {Body = "The body content", Subject = notificationTemplate.Subject};
+            var service = new NotificationTemplateService(repository);
+
+            // ACT
+            var actual = await service.CreateNotification(templateData);
+
+            // ASSERT
+            actual.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/PictureApp.API.Tests/Services/UserServiceTests.cs
+++ b/PictureApp.API.Tests/Services/UserServiceTests.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Net.Mail;
-using System.Threading.Tasks;
 using AutoMapper;
 using FluentAssertions;
 using NSubstitute;
@@ -51,6 +49,21 @@ namespace PictureApp.API.Tests.Services
 
             // ACT & ASSERT
             action.Should().Throw<EntityNotFoundException>().WithMessage($"user by id {userId} not found");
-        }        
+        }
+
+        [Test]
+        public void GetUser_WhenCalledWithEmailThatIsNotAssociatedWithAnyUser_EntityNotFoundExceptionExpected()
+        {
+            // ARRANGE
+            var repository = Substitute.For<IRepository<User>>();
+            repository.Find(Arg.Any<Expression<Func<User, bool>>>()).Returns(new List<User>());
+            var service = new UserService(repository,
+                Substitute.For<IMapper>());
+            var userEmail = "name.surname@domain.com";
+            Func<UserForDetailedDto> action = () => service.GetUser(userEmail);
+
+            // ACT & ASSERT
+            action.Should().Throw<EntityNotFoundException>().WithMessage($"User identifies by email {userEmail} does not exist in data store");
+        }
     }
 }

--- a/PictureApp.API.Tests/Services/UserServiceTests.cs
+++ b/PictureApp.API.Tests/Services/UserServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using AutoMapper;
 using FluentAssertions;
+using Newtonsoft.Json;
 using NSubstitute;
 using NUnit.Framework;
 using PictureApp.API.Data.Repositories;

--- a/PictureApp.API/Controllers/AuthController.cs
+++ b/PictureApp.API/Controllers/AuthController.cs
@@ -1,10 +1,15 @@
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 using PictureApp.API.Dtos;
+using PictureApp.API.Extensions.Exceptions;
 using PictureApp.API.Providers;
 using PictureApp.API.Services;
+using PictureApp.Messaging;
 
 namespace PictureApp.API.Controllers
 {
@@ -12,12 +17,14 @@ namespace PictureApp.API.Controllers
     [ApiController]
     public class AuthController : ControllerBase
     {
-        private readonly IAuthTokenProvider _jwtToken;
+        private readonly IAuthTokenProvider _authTokenProvider;
         private readonly IAuthService _authService;
+        private IUserService _userService;
+        private IMediator _mediator;
 
-        public AuthController(IAuthTokenProvider jwtToken, IAuthService authService)
+        public AuthController(IAuthTokenProvider authTokenProvider, IAuthService authService)
         {
-            _jwtToken = jwtToken ?? throw new ArgumentNullException(nameof(jwtToken));
+            _authTokenProvider = authTokenProvider ?? throw new ArgumentNullException(nameof(authTokenProvider));
             _authService = authService ?? throw new ArgumentNullException(nameof(authService));
         }
 
@@ -32,8 +39,38 @@ namespace PictureApp.API.Controllers
             }
 
             await Task.Run(() => _authService.Register(userForRegister));
-            
-            return StatusCode(201);
+
+            // co jest do zorbienia?
+            // - odczytanie uzytkownika na podstawie emaila (IUserService)
+            // - odczytanie jego tokena aktywacyjnego
+            // - wygenerowanie linka aktywacyjnego
+            // - opublikowanie wiadomosci o rejestracji uzytkownika w MediatR /api/Auth/Activate/token
+
+            //var user = _userService.GetUser(userForRegister.Email);
+            //var activationUrl = $"api/auth/activate/{user.ActivationToken}";
+            await _mediator.Publish(new UserRegisteredNotificationEvent(userForRegister.Email));
+
+            return StatusCode(StatusCodes.Status201Created);
+        }
+
+        [HttpPost("activate")]
+        public async Task<IActionResult> Activate(string token)
+        {
+            try
+            {
+                await _authService.Activate(token);
+            }
+            catch (Exception ex)
+            {
+                if (ex is SecurityTokenExpiredException || ex is EntityNotFoundException)
+                {
+                    return BadRequest("User can not be activated: token expired or does not exist");
+                }
+
+                throw;
+            }
+                        
+            return StatusCode(StatusCodes.Status201Created);
         }
 
         [HttpPost("login")]
@@ -44,7 +81,7 @@ namespace PictureApp.API.Controllers
             if (userForLoggedDto == null)
                 return Unauthorized();
 
-            var token = _jwtToken.GetToken(
+            var token = _authTokenProvider.GetToken(
                 new Claim(ClaimTypes.NameIdentifier, userForLoggedDto.Id.ToString()),
                 new Claim(ClaimTypes.Email, userForLoggedDto.Email),
                 new Claim(ClaimTypes.Name, userForLoggedDto.Username));                

--- a/PictureApp.API/Controllers/AuthController.cs
+++ b/PictureApp.API/Controllers/AuthController.cs
@@ -19,46 +19,38 @@ namespace PictureApp.API.Controllers
     {
         private readonly IAuthTokenProvider _authTokenProvider;
         private readonly IAuthService _authService;
-        private IUserService _userService;
-        private IMediator _mediator;
-
-        public AuthController(IAuthTokenProvider authTokenProvider, IAuthService authService)
+        private readonly IMediator _mediator;
+        
+        public AuthController(IAuthTokenProvider authTokenProvider, IAuthService authService, IMediator mediator)
         {
             _authTokenProvider = authTokenProvider ?? throw new ArgumentNullException(nameof(authTokenProvider));
             _authService = authService ?? throw new ArgumentNullException(nameof(authService));
+            _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         }
 
         [HttpPost("register")]
         public async Task<IActionResult> Register(UserForRegisterDto userForRegister)
         {
             userForRegister.Email = userForRegister.Email.ToLower();
-
+            
             if (await _authService.UserExists(userForRegister.Email))
             {
                 return BadRequest("User name already exists");
             }
 
             await Task.Run(() => _authService.Register(userForRegister));
-
-            // co jest do zorbienia?
-            // - odczytanie uzytkownika na podstawie emaila (IUserService)
-            // - odczytanie jego tokena aktywacyjnego
-            // - wygenerowanie linka aktywacyjnego
-            // - opublikowanie wiadomosci o rejestracji uzytkownika w MediatR /api/Auth/Activate/token
-
-            //var user = _userService.GetUser(userForRegister.Email);
-            //var activationUrl = $"api/auth/activate/{user.ActivationToken}";
+            
             await _mediator.Publish(new UserRegisteredNotificationEvent(userForRegister.Email));
-
+            
             return StatusCode(StatusCodes.Status201Created);
         }
 
         [HttpPost("activate")]
-        public async Task<IActionResult> Activate(string token)
+        public async Task<IActionResult> Activate(UserForRegisterActivateDto userForRegisterActivate)
         {
             try
             {
-                await _authService.Activate(token);
+                await _authService.Activate(userForRegisterActivate.Token);
             }
             catch (Exception ex)
             {

--- a/PictureApp.API/Helpers/AutoMapperProfiles.cs
+++ b/PictureApp.API/Helpers/AutoMapperProfiles.cs
@@ -24,15 +24,14 @@ namespace PictureApp.API.Helpers
                 .ForMember(dest => dest.Password, opt => opt.Ignore());
             CreateMap<User, UserLoggedInDto>();
             CreateMap<User, UserForDetailedDto>()
-                .ForMember(dest => dest.PhotoUrl, opt => {
-                    opt.MapFrom(src => src.Photos.FirstOrDefault(p => p.IsMain).Url);
-                });
+                .ForMember(dest => dest.PhotoUrl,
+                    opt => { opt.MapFrom(src => src.Photos.FirstOrDefault(p => p.IsMain).Url); }).ForMember(
+                    dest => dest.ActivationToken,
+                    opt => { opt.MapFrom(src => src.ActivationToken != null ? src.ActivationToken.Token : null); });
             CreateMap<User, UsersListWithFollowersForExploreDto>()
                 .ForMember(dest => dest.IsFollowerForCurrentUser, opt => {
                     opt.MapFrom(src => src.Following.Any(x => x.FolloweeId == src.Id));
-                })
-                .ForMember(dest => dest.ActivationToken,
-                opt => { opt.MapFrom(src => src.ActivationToken != null ? src.ActivationToken.Token : null); });
+                });               
         }
     }
 }

--- a/PictureApp.API/Helpers/AutoMapperProfiles.cs
+++ b/PictureApp.API/Helpers/AutoMapperProfiles.cs
@@ -24,9 +24,10 @@ namespace PictureApp.API.Helpers
                 .ForMember(dest => dest.Password, opt => opt.Ignore());
             CreateMap<User, UserLoggedInDto>();
             CreateMap<User, UserForDetailedDto>()
-                .ForMember(dest => dest.PhotoUrl, opt => {
-                    opt.MapFrom(src => src.Photos.FirstOrDefault(p => p.IsMain).Url);
-                });                               
+                .ForMember(dest => dest.PhotoUrl,
+                    opt => { opt.MapFrom(src => src.Photos.FirstOrDefault(p => p.IsMain).Url); })
+                .ForMember(dest => dest.ActivationToken,
+                    opt => { opt.MapFrom(src => src.ActivationToken != null ? src.ActivationToken.Token : null); });
         }
     }
 }

--- a/PictureApp.API/PictureApp.API.csproj
+++ b/PictureApp.API/PictureApp.API.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="mediatr.Extensions.microsoft.DependencyInjection" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PictureApp.API.Data\PictureApp.API.Data.csproj" />

--- a/PictureApp.API/PictureApp.API.csproj
+++ b/PictureApp.API/PictureApp.API.csproj
@@ -10,11 +10,14 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="mediatr" Version="5.1.0" />
+    <PackageReference Include="mediatr.Extensions.microsoft.DependencyInjection" Version="5.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PictureApp.API.Data\PictureApp.API.Data.csproj" />
     <ProjectReference Include="..\PictureApp.API.Services\PictureApp.API.Services.csproj" />
+    <ProjectReference Include="..\PictureApp.Messaging\PictureApp.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/PictureApp.API/SeedData/Seed.cs
+++ b/PictureApp.API/SeedData/Seed.cs
@@ -32,6 +32,21 @@ namespace PictureApp.API.SeedData
             context.SaveChanges();
         }
 
+        public void SeedNotificationTemplates()
+        {
+            var notificationTemplate = new NotificationTemplate
+            {
+                Name = "Activation of an account after registration",
+                Abbreviation = "ARR",
+                Description = "This template is using for notify users who has just registered their account and need a full activation.",
+                Body = "Dear user {UserName}, <br /> Here is your activation link: <a href=\"{ActivationUri}\">{ActivationUri}</a>.",
+                Subject = "Account activation"
+            };
+
+            context.Add(notificationTemplate);
+            context.SaveChanges();
+        }
+
         private void CreatePasswordHash(string password, out byte[] passwordHash, out byte[] passwordSalt)
         {
             using (var hmac = new System.Security.Cryptography.HMACSHA512())
@@ -39,7 +54,6 @@ namespace PictureApp.API.SeedData
                 passwordSalt = hmac.Key;
                 passwordHash = hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes(password));
             }
-        }
-        
+        }               
     }
 }

--- a/PictureApp.API/appsettings.json
+++ b/PictureApp.API/appsettings.json
@@ -6,7 +6,8 @@
     "MailServiceHost": "smtp.gmail.com",
     "MailServicePort": "465",
     "MailServiceAuthenticationUserName": "picture.app.noreply@gmail.com",
-    "MailServiceAuthenticationUserPassword": ""
+    "MailServiceAuthenticationUserPassword": "",
+    "AccountActivationUriFormat": "http://localhost:4200/AccountActivate/{token}"
   },
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=DatingApp.db"

--- a/PictureApp.Messaging/PictureApp.Messaging.csproj
+++ b/PictureApp.Messaging/PictureApp.Messaging.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="mediatr" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PictureApp.API.Data\PictureApp.API.Data.csproj" />
+    <ProjectReference Include="..\PictureApp.API.Models\PictureApp.API.Models.csproj" />
+    <ProjectReference Include="..\PictureApp.API.Services\PictureApp.API.Services.csproj" />
+    <ProjectReference Include="..\PictureApp.Notifications\PictureApp.Notifications.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PictureApp.Messaging/UserRegisteredNotificationEvent.cs
+++ b/PictureApp.Messaging/UserRegisteredNotificationEvent.cs
@@ -1,0 +1,14 @@
+﻿using MediatR;
+
+namespace PictureApp.Messaging
+{
+    public class UserRegisteredNotificationEvent : INotification
+    {
+        public UserRegisteredNotificationEvent(string userEmail)
+        {
+            UserEmail = userEmail;
+        }
+
+        public string UserEmail { get; }
+    }
+}

--- a/PictureApp.Messaging/UserRegisteredNotificationHandler.cs
+++ b/PictureApp.Messaging/UserRegisteredNotificationHandler.cs
@@ -2,8 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
-using PictureApp.API.Data.Repositories;
-using PictureApp.API.Models;
+using Microsoft.Extensions.Configuration;
 using PictureApp.API.Services;
 using PictureApp.Notifications;
 
@@ -11,33 +10,33 @@ namespace PictureApp.Messaging
 {
     public class UserRegisteredNotificationHandler : INotificationHandler<UserRegisteredNotificationEvent>
     {
-        private INotificationService _notificationService;
-        private IUserService _userService;
-        private IRepository<NotificationTemplate> _repository;
-
-        public UserRegisteredNotificationHandler(INotificationService notificationService, IUserService userService, IRepository<NotificationTemplate> repository)
+        private readonly INotificationService _notificationService;
+        private readonly IUserService _userService;
+        private readonly IConfiguration _configuration;
+        
+        public UserRegisteredNotificationHandler(INotificationService notificationService, IUserService userService, IConfiguration configuration)
         {
             _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
             _userService = userService ?? throw new ArgumentNullException(nameof(userService));
-            _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
         public async Task Handle(UserRegisteredNotificationEvent notification, CancellationToken cancellationToken)
         {
+            // Get the user by his email
             var user = _userService.GetUser(notification.UserEmail);
+            if (user == null)
+            {
+                throw new ArgumentException($"The user with given email: {notification.UserEmail} does not exist in data store");
+            }
 
-            var templateData = new UserRegisteredNotificationTemplateData(user.ActivationToken, user.Username);
-            // na podstawie emaila odczytanie id uzytkownika
-            // odczytanie wlasciwego template'a do notyfikacji
-            // wypelnienie template'a danymi
+            // Prepare activation uri
+            var activationUriFormat = _configuration.GetSection("AppSettings:AccountActivationUriFormat").Value;
+            var activationUri = Uri.EscapeUriString(activationUriFormat.Replace("{token}", user.ActivationToken));
 
-
-            // wyslanie maila do uzytkownika
-            await _notificationService.SendAsync(user.Email, templateData);
-
-            // jakie zaleznosci?
-            // - INotificationService - wyslanie maila
-            // - IRepository<NotificationTemplate> - odczytanie odpowiedniego template'a - a moze tutaj powinien byc odpowiedni serwis, ktory pozwala na odczytanie odpowiednich template'ow?            
+            // Prepare notification with activation uri
+            var templateData = new UserRegisteredNotificationTemplateData(activationUri, user.Username);
+            await _notificationService.SendAsync(user.Email, templateData);                      
         }
     }
 }

--- a/PictureApp.Messaging/UserRegisteredNotificationHandler.cs
+++ b/PictureApp.Messaging/UserRegisteredNotificationHandler.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using PictureApp.API.Data.Repositories;
+using PictureApp.API.Models;
+using PictureApp.API.Services;
+using PictureApp.Notifications;
+
+namespace PictureApp.Messaging
+{
+    public class UserRegisteredNotificationHandler : INotificationHandler<UserRegisteredNotificationEvent>
+    {
+        private INotificationService _notificationService;
+        private IUserService _userService;
+        private IRepository<NotificationTemplate> _repository;
+
+        public UserRegisteredNotificationHandler(INotificationService notificationService, IUserService userService, IRepository<NotificationTemplate> repository)
+        {
+            _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
+            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        }
+
+        public async Task Handle(UserRegisteredNotificationEvent notification, CancellationToken cancellationToken)
+        {
+            var user = _userService.GetUser(notification.UserEmail);
+
+            var templateData = new UserRegisteredNotificationTemplateData(user.ActivationToken, user.Username);
+            // na podstawie emaila odczytanie id uzytkownika
+            // odczytanie wlasciwego template'a do notyfikacji
+            // wypelnienie template'a danymi
+
+
+            // wyslanie maila do uzytkownika
+            await _notificationService.SendAsync(user.Email, templateData);
+
+            // jakie zaleznosci?
+            // - INotificationService - wyslanie maila
+            // - IRepository<NotificationTemplate> - odczytanie odpowiedniego template'a - a moze tutaj powinien byc odpowiedni serwis, ktory pozwala na odczytanie odpowiednich template'ow?            
+        }
+    }
+}

--- a/PictureApp.Notifications/INotificationTemplateData.cs
+++ b/PictureApp.Notifications/INotificationTemplateData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace PictureApp.API.Services.NotificationTemplateData
+namespace PictureApp.Notifications
 {
     public interface INotificationTemplateData
     {

--- a/PictureApp.Notifications/NotificationTemplateData.cs
+++ b/PictureApp.Notifications/NotificationTemplateData.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace PictureApp.API.Services.NotificationTemplateData
+namespace PictureApp.Notifications
 {
     public abstract class NotificationTemplateData : INotificationTemplateData
     {
@@ -16,6 +16,18 @@ namespace PictureApp.API.Services.NotificationTemplateData
         public string GetValue(string key)
         {
             return DataContainer[key];
+        }
+
+        protected void SetDataContainerItem(string key, string value)
+        {
+            if (DataContainer.ContainsKey(key))
+            {
+                DataContainer[key] = value;
+            }
+            else
+            {
+                DataContainer.Add(key, value);
+            }
         }
         
         protected abstract string GetTemplateAbbreviation();

--- a/PictureApp.Notifications/PictureApp.Notifications.csproj
+++ b/PictureApp.Notifications/PictureApp.Notifications.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/PictureApp.Notifications/UserRegisteredNotificationTemplateData.cs
+++ b/PictureApp.Notifications/UserRegisteredNotificationTemplateData.cs
@@ -4,27 +4,27 @@ namespace PictureApp.Notifications
 {
     public class UserRegisteredNotificationTemplateData : NotificationTemplateData
     {
-        public string ActivationToken
+        public string ActivationUri
         {
-            get => GetValue(nameof(ActivationToken)); // TODO: sprawdzenie czy klucz istnieje, jezeli brak to zwrocenie domyslnej wartosci
-            private set => SetDataContainerItem(nameof(ActivationToken), value);
+            get => GetValue($"{{{nameof(ActivationUri)}}}");
+            private set => SetDataContainerItem($"{{{nameof(ActivationUri)}}}", value);
         }
 
         public string UserName
         {
-            get => GetValue(nameof(UserName));
-            private set => SetDataContainerItem(nameof(UserName), value);
+            get => GetValue($"{{{nameof(UserName)}}}");
+            private set => SetDataContainerItem($"{{{nameof(UserName)}}}", value);
         }
 
-        public UserRegisteredNotificationTemplateData(string activationToken, string userName)
+        public UserRegisteredNotificationTemplateData(string activationUri, string userName)
         {
-            ActivationToken = activationToken;
+            ActivationUri = activationUri;
             UserName = userName;
         }
 
         protected override string GetTemplateAbbreviation()
         {
-            throw new NotImplementedException();
+            return "ARR";
         }
     }
 }

--- a/PictureApp.Notifications/UserRegisteredNotificationTemplateData.cs
+++ b/PictureApp.Notifications/UserRegisteredNotificationTemplateData.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace PictureApp.Notifications
+{
+    public class UserRegisteredNotificationTemplateData : NotificationTemplateData
+    {
+        public string ActivationToken
+        {
+            get => GetValue(nameof(ActivationToken)); // TODO: sprawdzenie czy klucz istnieje, jezeli brak to zwrocenie domyslnej wartosci
+            private set => SetDataContainerItem(nameof(ActivationToken), value);
+        }
+
+        public string UserName
+        {
+            get => GetValue(nameof(UserName));
+            private set => SetDataContainerItem(nameof(UserName), value);
+        }
+
+        public UserRegisteredNotificationTemplateData(string activationToken, string userName)
+        {
+            ActivationToken = activationToken;
+            UserName = userName;
+        }
+
+        protected override string GetTemplateAbbreviation()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/PictureApp_API.sln
+++ b/PictureApp_API.sln
@@ -15,9 +15,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PictureApp.API.Models", "Pi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PictureApp.API.Providers", "PictureApp.API.Providers\PictureApp.API.Providers.csproj", "{94BF57A8-9E48-4FDF-A3A1-D48B1ED4F63C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PictureApp.API.Extensions", "PictureApp.API.Extensions\PictureApp.API.Extensions.csproj", "{79BC3F56-01CB-4D73-B3BD-7D7F2C8D608C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PictureApp.API.Extensions", "PictureApp.API.Extensions\PictureApp.API.Extensions.csproj", "{79BC3F56-01CB-4D73-B3BD-7D7F2C8D608C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PictureApp.API.Dtos", "PictureApp.API.Dtos\PictureApp.API.Dtos.csproj", "{E0A8D474-CE98-4B76-BC70-D2AD8A8039C5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PictureApp.API.Dtos", "PictureApp.API.Dtos\PictureApp.API.Dtos.csproj", "{E0A8D474-CE98-4B76-BC70-D2AD8A8039C5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PictureApp.Messaging", "PictureApp.Messaging\PictureApp.Messaging.csproj", "{DBA77C92-C7D8-4F22-93C9-FFC365F9D156}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PictureApp.Notifications", "PictureApp.Notifications\PictureApp.Notifications.csproj", "{C7342E39-4829-4670-B9B7-C25E0521D03C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +61,14 @@ Global
 		{E0A8D474-CE98-4B76-BC70-D2AD8A8039C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0A8D474-CE98-4B76-BC70-D2AD8A8039C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E0A8D474-CE98-4B76-BC70-D2AD8A8039C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBA77C92-C7D8-4F22-93C9-FFC365F9D156}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBA77C92-C7D8-4F22-93C9-FFC365F9D156}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBA77C92-C7D8-4F22-93C9-FFC365F9D156}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBA77C92-C7D8-4F22-93C9-FFC365F9D156}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7342E39-4829-4670-B9B7-C25E0521D03C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7342E39-4829-4670-B9B7-C25E0521D03C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7342E39-4829-4670-B9B7-C25E0521D03C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7342E39-4829-4670-B9B7-C25E0521D03C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is set of changes provided in AuthController in order to support account activation after user registration.
There are some prerequisites before run the new feature:
1) it is necessary to have a proper notification template in order to deal with sending email to registered user. The NotificationTemplate table can be easily fulfilled when seed method is uncommented during first execution (`seed.SeedNotificationTemplates()`) 
2) do not forget to setup MailServiceAuthenticationUserPassword in appsettings.json configuration file, otherwise application will not be able to authenticate to our mailbox. All credentials are stored in  Evernote.